### PR TITLE
Handle "named" workspaces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ fn next_workspace_number(conn: &mut swayipc::Connection) -> Result<i32, swayipc:
     let mut ids: Vec<i32> = workspaces
         .iter()
         .map(|w| w.num)
-        .filter(|workspace_num| *workspace_num > 0)
+        .filter(|w| *w > 0)
         .collect();
     ids.sort_unstable();
     let len = ids.len() as i32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,11 @@ use clap::{app_from_crate, App, AppSettings};
 
 fn next_workspace_number(conn: &mut swayipc::Connection) -> Result<i32, swayipc::Error> {
     let workspaces = conn.get_workspaces()?;
-    let mut ids: Vec<i32> = workspaces.iter().map(|w| w.num).collect();
+    let mut ids: Vec<i32> = workspaces
+        .iter()
+        .map(|w| w.num)
+        .filter(|workspace_num| *workspace_num > 0)
+        .collect();
     ids.sort_unstable();
     let len = ids.len() as i32;
     Ok(ids


### PR DESCRIPTION
I use a combination of "named" long-lived workspaces (where `.name` is a string as opposed to just a number) and plain numbered workspaces in Sway. When I have a mix of these open and try to use `sway-new-workspace open` it just switches to one of my "named" workspaces instead of creating a new "numbered" workspace.

This is due to the `.num` field of the "named" workspaces being reported as `-1` (at least on my version of sway: 1.6.1). This throws off sway-new-workspace's way of determining which is the next available unused number for the new workspace.

The fix/change is simply to ignore "named" workspaces (i.e. those with `.num` == -1).